### PR TITLE
More examples for board rev. c

### DIFF
--- a/assembler/examples/1-bit-adder.asm
+++ b/assembler/examples/1-bit-adder.asm
@@ -1,0 +1,57 @@
+;
+; 1 Bit Full Adder: A1 + B1 + C0 (carry-in) = R1 (result) + C1 (carry-out)
+;
+; Usage:
+; - set value A1 (IN0)
+; - set value B1 (IN1)
+; - set carry-in (IN2)
+; - OUT0 shows the result (R1)
+; - OUT1 shows the carry-out
+;
+; This full adder doesn't need a Scratch Register for intermediate results!
+;
+
+.board=PLC14500-Nano
+
+.io_A1 = IN0
+.io_B1 = IN1
+.io_C0 = IN2
+.io_R1 = OUT0
+.io_C1 = OUT1
+
+;
+; Prepare: Enable input
+;
+
+ORC  RR
+IEN  RR
+OEN  RR
+
+;
+; ADD A1 + B1 + C0 -> R1 + C1
+;
+
+; Calculate result -> R1
+
+LD   A1
+XNOR B1
+XNOR C0
+STO  R1
+
+; Calculate next carry -> C1
+
+LD   A1
+AND  B1
+IEN  C0
+OR   A1
+OR   B1
+STO  C1
+
+; Re-enable input
+
+ORC  RR
+IEN  RR
+
+; Loop back
+
+JMP  0

--- a/assembler/examples/6-bit-adder.asm
+++ b/assembler/examples/6-bit-adder.asm
@@ -1,0 +1,186 @@
+;
+; 6 Bit Full Adder: A1-6 + B1-6 = R1-6, OUT6 = Carry out
+;
+; Usage:
+; - switch IN6 -> ON to load IN0-5 into SPR0-5 (second operand = B1-6)
+; - then switch IN6 -> OFF and set IN0-5 (first operand = A1-6)
+; - OUT0-5 shows the result (= R1-6), OUT6 is the carry
+;
+; SPR6 is used as intermediate carry while calculating
+;
+
+.board=PLC14500-Nano
+
+;
+; Intermediate carry
+;
+.io_C-TMP = SPR6
+
+;
+; First operand
+;
+.io_A1 = IN0
+.io_A2 = IN1
+.io_A3 = IN2
+.io_A4 = IN3
+.io_A5 = IN4
+.io_A6 = IN5
+
+;
+; Second operand
+;
+.io_B1 = SPR0
+.io_B2 = SPR1
+.io_B3 = SPR2
+.io_B4 = SPR3
+.io_B5 = SPR4
+.io_B6 = SPR5
+
+;
+; Result
+;
+.io_R1 = OUT0
+.io_R2 = OUT1
+.io_R3 = OUT2
+.io_R4 = OUT3
+.io_R5 = OUT4
+.io_R6 = OUT5
+
+;
+; Carry-out
+;
+.io_C-OUT = OUT6
+
+;
+; Prepare: Enable input
+;
+
+ORC  RR
+IEN  RR
+
+; Write A1-6 to B1-6 if IN6 is set
+OEN  IN6
+
+LD   A1
+STO  B1
+LD   A2
+STO  B2
+LD   A3
+STO  B3
+LD   A4
+STO  B4
+LD   A5
+STO  B5
+LD   A6
+STO  B6
+
+ORC  RR
+OEN  RR
+
+;
+; Do the calculations
+;
+
+; 1st bit - half adder
+
+LD   A1
+XNOR B1
+STOC R1
+
+LD   A1
+AND  B1
+STO  C-TMP
+
+; 2nd bit - full adder
+
+LD   A2
+XNOR B2
+XNOR C-TMP
+STO  R2
+
+LD   A2
+AND  B2
+IEN  C-TMP
+OR   A2
+OR   B2
+STO  C-TMP
+
+ORC  RR
+IEN  RR
+
+; 3rd bit - full adder
+
+LD   A3
+XNOR B3
+XNOR C-TMP
+STO  R3
+
+LD   A3
+AND  B3
+IEN  C-TMP
+OR   A3
+OR   B3
+STO  C-TMP
+
+ORC  RR
+IEN  RR
+
+; 4th bit - full adder
+
+LD   A4
+XNOR B4
+XNOR C-TMP
+STO  R4
+
+LD   A4
+AND  B4
+IEN  C-TMP
+OR   A4
+OR   B4
+STO  C-TMP
+
+ORC  RR
+IEN  RR
+
+; 5th bit - full adder
+
+LD   A5
+XNOR B5
+XNOR C-TMP
+STO  R5
+
+LD   A5
+AND  B5
+IEN  C-TMP
+OR   A5
+OR   B5
+STO  C-TMP
+
+ORC  RR
+IEN  RR
+
+; 6th bit - full adder
+
+LD   A6
+XNOR B6
+XNOR C-TMP
+STO  R6
+
+LD   A6
+AND  B6
+IEN  C-TMP
+OR   A6
+OR   B6
+STO  C-TMP
+
+ORC  RR
+IEN  RR
+
+; 7th bit - show carry
+
+LD   C-TMP
+STO  C-OUT
+
+; Loop back
+
+JMP  0

--- a/assembler/examples/smoketest2.asm
+++ b/assembler/examples/smoketest2.asm
@@ -1,0 +1,129 @@
+;
+; Another smoke test for PLC14500-Nano (Rev_C).
+;
+; This shall test the following:
+; - IN0-6 (buttons and switches)
+; - OUT0-6 (LEDs, activated by IN0-6)
+; - Timer TMR0 (IN7, OUT7)
+; - SPR0-6 (running light)
+; - ADDR0-7 (by omitting the last JMP)
+; - DATA0-7, J, RR, W (indirectly)
+;
+
+.board=PLC14500-Nano
+
+;
+; Prepare: Enable input and output
+;
+
+ORC  RR
+IEN  RR
+OEN  RR
+
+;
+; Test: Copy IN0 - IN6 to OUT0 - OUT6
+; The user can test all inputs and outputs using the switches and buttons
+;
+
+LD   IN0
+STO  OUT0
+
+LD   IN1
+STO  OUT1
+
+LD   IN2
+STO  OUT2
+
+LD   IN3
+STO  OUT3
+
+LD   IN4
+STO  OUT4
+
+LD   IN5
+STO  OUT5
+
+LD   IN6
+STO  OUT6
+
+;
+; Test: Start timer TMR0 when elapsed (set 0 -> 1)
+;
+
+LD   TMR0-OUT
+STOC TMR0-TRIG
+
+;
+; Loop if timer TMR0 hasn't elapsed
+;
+
+SKZ
+JMP  0
+
+;
+; Timer has elapsed -> move running SPR light
+;
+
+; Move SPR 5 -> 6
+; If SPR5 is 1 -> set to 0 and jump back
+
+LD   SPR5
+STO  SPR6
+SKZ
+STOC SPR5
+SKZ
+JMP  0
+
+; Move SPR 4 -> 5
+
+LD   SPR4
+STO  SPR5
+SKZ
+STOC SPR4
+SKZ
+JMP  0
+
+; Move SPR 3 -> 4
+
+LD   SPR3
+STO  SPR4
+SKZ
+STOC SPR3
+SKZ
+JMP  0
+
+; Move SPR 2 -> 3
+
+LD   SPR2
+STO  SPR3
+SKZ
+STOC SPR2
+SKZ
+JMP  0
+
+; Move SPR 1 -> 2
+
+LD   SPR1
+STO  SPR2
+SKZ
+STOC SPR1
+SKZ
+JMP  0
+
+; Move SPR 0 -> 1
+
+LD   SPR0
+STO  SPR1
+SKZ
+STOC SPR0
+SKZ
+JMP  0
+
+; If this point is reached SPR0 - 6 are all 0
+; -> The running light needs to be initialized
+
+ORC  RR
+STO  SPR0
+
+; Intentionally commented out to test ADDR6 + 7
+; JMP  0


### PR DESCRIPTION
I have new examples for you:
1. A 1-Bit Full Adder (i.e. with carry-in and -out) which doesn't need a Scratch Register for intermediate results.
2. A 6-Bit Adder where you can select two 6-bit values to be added, one is stored in the Scratch Register SPR0-5 and one in IN0-5, OUT0-6 shows the 7-bit result (with carry-out).
3. Another smoke test to test all LEDs, buttons and the timer 0.
